### PR TITLE
Chris

### DIFF
--- a/consul/init.sls
+++ b/consul/init.sls
@@ -52,11 +52,16 @@ consul|deploy-config:
 
 consul|install-consul:
   archive.extracted:
-  - name: {{ consul.install_path }}
-  - source: {{ consul.source_url }}
-  - source_hash: {{ consul.source_hash }}
-  - archive_format: zip
-  - if_missing: {{ consul.install_path }}/consul
+    - name: {{ consul.install_path }}
+    - source: {{ consul.source_url }}
+    - source_hash: {{ consul.source_hash }}
+    - archive_format: zip
+    - if_missing: {{ consul.install_path }}/consul
+  file.managed:
+    - name: {{ consul.install_path }}/consul
+    - mode: 0755
+    - require:
+      - archive: consul|install-consul
 
 consul|deploy-upstart-config:
   file.managed:

--- a/consul/settings.sls
+++ b/consul/settings.sls
@@ -1,15 +1,15 @@
 {%- set install_path = salt['pillar.get']('consul:install_path', '/usr/local/bin') %}
-{%- set version = salt['pillar.get']('consul:version', '0.5.0') %}
+{%- set version = salt['pillar.get']('consul:version', '0.5.2') %}
 {%- set user = salt['pillar.get']('consul:user', 'consul') %}
 {%- set group = salt['pillar.get']('consul:group', 'consul') %}
 {%- set home_dir = salt['pillar.get']('consul:home', '/opt/consul') %}
 {%- set domain = salt['pillar.get']('consul:domain', 'consul.') %}
 
 {%- set source_url = 'https://dl.bintray.com/mitchellh/consul/' ~ version ~ '_linux_amd64.zip' %}
-{%- set source_hash =  salt['pillar.get']('consul:source_hash', 'md5=9ce296fccaca3180e6911df7fcd641e9') %}
+{%- set source_hash =  salt['pillar.get']('consul:source_hash', 'md5=37000419d608fd34f0f2d97806cf7399') %}
 
 {%- set ui_source_url = 'https://dl.bintray.com/mitchellh/consul/' ~ version ~ '_web_ui.zip' %}
-{%- set ui_source_hash = salt['pillar.get']('consul:ui_source_hash', 'md5=ba0bc4923a7d1da2a2b6092872c84822') %}
+{%- set ui_source_hash = salt['pillar.get']('consul:ui_source_hash', 'md5=eb98ba602bc7e177333eb2e520881f4f') %}
 
 {%- set targeting_method = salt['pillar.get']('consul:targeting_method', 'glob') %}
 {%- set server_target = salt['pillar.get']('consul:server_target') %}


### PR DESCRIPTION
In my rollout /usr/local/bin/consul wasn't executable so my patch will help with that.

I've also updated to 0.5.2
